### PR TITLE
This is a minor change, but it fixes a big annoyance with the generated solution - you couldn't double-click the .sln file to open the solution (at least for VS2010). I've seen no negative effects by writing as UTF8.

### DIFF
--- a/warmup/TargetDir.cs
+++ b/warmup/TargetDir.cs
@@ -64,7 +64,7 @@ namespace warmup
                 //process contents
                 string contents = File.ReadAllText(info.FullName);
                 contents = contents.Replace(_replacementToken, name);
-                File.WriteAllText(info.FullName, contents);
+                File.WriteAllText(info.FullName, contents, Encoding.UTF8);
             }
         }
 


### PR DESCRIPTION
fix issue with not being able to double-click .sln file to open new solution by writing all files with UTF8 encoding
