### PR TITLE
Allow token replacement for read only files

### DIFF
--- a/warmup.Tests/describe_TokenReplacement.cs
+++ b/warmup.Tests/describe_TokenReplacement.cs
@@ -17,6 +17,8 @@ namespace warmup.Tests
 
         void file_encodings()
         {
+            beforeEach = () => File.SetAttributes(@"BomTestFiles\DynamicBlog.slnfile", FileAttributes.ReadOnly);
+
             it["UTF8 encoding is retained after token replacement"] = () =>
             {
                 string slnFile = @"BomTestFiles\DynamicBlog.slnfile";
@@ -38,6 +40,8 @@ namespace warmup.Tests
 
         void replacing_tokens()
         {
+            before = () => File.SetAttributes(@"BomTestFiles\DynamicBlog.slnfile", FileAttributes.ReadOnly);
+
             it["tokens in file are replaced with new value"] = () =>
             {
                 string slnFile = @"BomTestFiles\DynamicBlog.slnfile";


### PR DESCRIPTION
I have made an edit to perform token replacement on readonly files to resolve Issue #12.

Readonly files are no longer skipped.

During token replacement, the read only attribute is removed temporarily, the tokens are replaced, and the file is again made read only.
